### PR TITLE
Make duct/server.http.jetty dependency :excludable

### DIFF
--- a/src/duct/module/web.clj
+++ b/src/duct/module/web.clj
@@ -6,9 +6,10 @@
             [duct.core.merge :as merge]
             [duct.core.web :as web]
             [duct.middleware.web :as mw]
-            [duct.server.http.jetty :as jetty]
             [integrant.core :as ig]
             [ring.middleware.defaults :as defaults]))
+
+(derive :duct.server.http/jetty :duct.server/http)
 
 (def ^:private server-port
   (env/env '["PORT" Int :or 3000]))


### PR DESCRIPTION
I swapped out jetty for immutant and tried to change my `:dependencies` entry to 
```clojure
[duct/module.web "0.2.0" :exclusions [duct/server.http.jetty]]
```
since I prefer to keep my dependency trees as clean as possible. 😀 
This failed due to the `require` in `duct.module.web`
The namespace containing the default (jetty) server seems to be necessary to pass the tests, so I changed it to be loaded only when no other `:duct.server/http` is defined.

I wonder why that is required, since duct seems to run [`load-namespaces`](https://github.com/duct-framework/core/blob/e8b6f58ad66629d84983fb4fcf1e52763ccb2798/src/duct/core.clj#L118-L119) once more after applying modules.
```clojure
(defn prep
  "Prep a configuration, ready to be initiated. Key namespaces are loaded,
  and modules are applied."
  [config]
  (-> config
      (doto ig/load-namespaces)
      (apply-modules)
      (doto ig/load-namespaces)))
```