### PR TITLE
Improve format middleware option merge

### DIFF
--- a/src/duct/middleware/web.clj
+++ b/src/duct/middleware/web.clj
@@ -118,5 +118,11 @@
 (defmethod ig/init-key ::stacktrace [_ options]
   #(wrap-stacktrace % options))
 
+(defn- deep-merge
+  [a b]
+  (if (and (map? a) (map b))
+    (merge-with deep-merge a b)
+    b))
+
 (defmethod ig/init-key ::format [_ options]
-  #(mm/wrap-format % (merge-with merge mc/default-options options)))
+  #(mm/wrap-format % (deep-merge mc/default-options options)))


### PR DESCRIPTION
Not it's possible to write

```clojure
:duct.middleware.web/format {:default-format "application/transit+json"}
```