### PR TITLE
Fix deep-merge recursive case

### DIFF
--- a/src/duct/middleware/web.clj
+++ b/src/duct/middleware/web.clj
@@ -119,7 +119,7 @@
   #(wrap-stacktrace % options))
 
 (defn- deep-merge [a b]
-  (if (and (map? a) (map b))
+  (if (and (map? a) (map? b))
     (merge-with deep-merge a b)
     b))
 


### PR DESCRIPTION
I was browsing through the code and noticed that the `deep-merge` function was checking if `a` is a map and if `(map b)` (the transducer) is truthy which I think is always going to be true but correct me if I'm wrong, I think it's supposed to be checking if `b` is also a map.