### PR TITLE
muuntaja 0.6.0, ring-defaults 0.3.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,12 +9,12 @@
                  [duct/server.http.jetty "0.2.0"]
                  [compojure "1.6.1"]
                  [integrant "0.7.0-alpha2"]
-                 [metosin/muuntaja "0.5.0"]
+                 [metosin/muuntaja "0.6.0"]
                  [org.slf4j/slf4j-nop "1.7.25"]
                  [org.webjars/normalize.css "5.0.0"]
                  [ring/ring-core "1.6.3"]
                  [ring/ring-devel "1.6.3"]
-                 [ring/ring-defaults "0.3.1"]
+                 [ring/ring-defaults "0.3.2"]
                  [ring-webjars "0.2.0"]]
   :profiles
   {:dev {:dependencies [[ring/ring-mock "0.3.2"]]}})


### PR DESCRIPTION
* Update Muuntaja to 0.6.0. Contains big changes (for the better), might might cause breakage on users.
  * https://github.com/metosin/muuntaja/blob/master/CHANGELOG.md#060-392018
  * post: https://www.metosin.fi/blog/muuntaja/
  * biggest ones:
     * change Cheshire to Jsonista for better perf and explicit options - Muuntaja fails fast if old option keys are used, but users who have leaned on `cheshire.generate/add-encoder` might see breakage as with Jsonista, the mappings are given as optiopns
     * if a response already contains header `"Content-Type"`, don't ever encode the response.