### PR TITLE
Remove sljf4j-nop logger to avoid swallowing logs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,6 @@
                  [compojure "1.6.1"]
                  [integrant "0.7.0"]
                  [metosin/muuntaja "0.6.3"]
-                 [org.slf4j/slf4j-nop "1.7.25"]
                  [org.webjars/normalize.css "5.0.0"]
                  [ring/ring-core "1.7.1"]
                  [ring/ring-devel "1.7.1"]


### PR DESCRIPTION
Hi James,

With the `slf4j-nop` included, in projects requiring `duct/module.web` all logs are swallowed when used in combination with `duct.logger.clojure`, clojure.tools.logging and Logback.

The way to avoid that is by explicitly excluding this dependency. E.g., in `project.clj`:

```
;; Exclusion needed to prevent slf4j 'no operation' logging to
;; take precedence over logback logging
[duct/module.web "0.7.0" :exclusions [org.slf4j/slf4j-nop]]
[org.clojure/tools.logging "1.0.0"]
[duct/logger.clojure "0.1.1"]
[ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]
[org.slf4j/slf4j-api "1.7.30"]
[org.slf4j/jul-to-slf4j "1.7.30"]
[org.slf4j/jcl-over-slf4j "1.7.30"]
[org.slf4j/log4j-over-slf4j "1.7.30"]
```

I don't know what the reason was to add  `slf4j-nop` (maybe it is to remove logging of Jetty or other type of `:duct.server/http`), so maybe this PR needs some changes to re-add that behaviour if so desired.

Kind regards,
Erwin
