### PR TITLE
Remove oraclejdk8 specification in .travis.yml to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,1 @@
 language: clojure
-jdk:
-  - oraclejdk8


### PR DESCRIPTION
According to this discussion: https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/9
oraclejdk8 fails because this travis config file doesn't specify a dist.
And apparently the dist it defaults to (currently Xenial) doesn't support oraclejdk8.
People in that discussion have reported that it works ok with Trusty.