### PR TITLE
Supporting log level for log-requests from configuration

### DIFF
--- a/test/duct/middleware/web_test.clj
+++ b/test/duct/middleware/web_test.clj
@@ -19,7 +19,16 @@
         (is (= (handler (mock/request :get "/")) response))
         (is (= @logs [[:info :duct.middleware.web/request
                        {:request-method :get, :uri "/"}]]))))
-    
+
+    (testing "synchronous with log level"
+      (let [logs    (atom [])
+            handler (wrap-log-requests (constantly response)
+                                       (->TestLogger logs)
+                                       {:level :trace})]
+        (is (= (handler (mock/request :get "/")) response))
+        (is (= @logs [[:trace :duct.middleware.web/request
+                       {:request-method :get, :uri "/"}]]))))
+
     (testing "asynchronous"
       (let [logs     (atom [])
             handler  (wrap-log-requests

--- a/test/duct/module/web_test.clj
+++ b/test/duct/module/web_test.clj
@@ -211,3 +211,21 @@
               :nested     true
               :keywordize true}
              (:params (:duct.middleware.web/defaults config')))))))
+
+(deftest log-requests-level-test
+  (testing "api config"
+    (let [config  (assoc-in site-config
+                            [:duct.profile/base :duct.middleware.web/defaults]
+                            {:duct.middleware.web/log-requests {:level :debug}})
+          config' (core/build-config config)]
+      (is (= {:level :debug}
+             (:duct.middleware.web/log-requests
+              (:duct.middleware.web/defaults config'))))))
+  (testing "site config"
+    (let [config  (assoc-in site-config
+                            [:duct.profile/base :duct.middleware.web/defaults]
+                            {:duct.middleware.web/log-requests {:level :debug}})
+          config' (core/build-config config)]
+      (is (= {:level :debug}
+             (:duct.middleware.web/log-requests
+              (:duct.middleware.web/defaults config')))))))


### PR DESCRIPTION
Add new configuration feature to modify log-requests' log level.

You can modify requests log level in your config like ...

```
:duct.middleware.web/log-requests {:level :debug}
```

Also you can hide all requests log like ...

```
:duct.middleware.web/log-requests {:level :debug}
:duct.logger/timbre {:level :info}
```
