### PR TITLE
Update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,19 +3,19 @@
   :url "https://github.com/duct-framework/module.web"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
-                 [duct/core "0.8.0"]
+  :dependencies [[org.clojure/clojure "1.11.4"]
+                 [duct/core "0.8.1"]
                  [duct/logger "0.3.0"]
                  [duct/server.http.jetty "0.2.1"]
-                 [compojure "1.6.2"]
-                 [integrant "0.8.0"]
-                 [metosin/jsonista "0.3.3"]
-                 [metosin/muuntaja "0.6.8"]
-                 [org.slf4j/slf4j-nop "1.7.31"]
+                 [compojure "1.7.1"]
+                 [integrant "0.13.0"]
+                 [metosin/jsonista "0.3.11"]
+                 [metosin/muuntaja "0.6.10"]
+                 [org.slf4j/slf4j-nop "2.0.16"]
                  [org.webjars/normalize.css "5.0.0"]
-                 [ring/ring-core "1.9.3"]
-                 [ring/ring-devel "1.9.3"]
-                 [ring/ring-defaults "0.3.3"]
-                 [ring-webjars "0.2.0"]]
+                 [ring/ring-core "1.13.0"]
+                 [ring/ring-devel "1.13.0"]
+                 [ring/ring-defaults "0.5.0"]
+                 [ring-webjars "0.3.0"]]
   :profiles
   {:dev {:dependencies [[ring/ring-mock "0.4.0"]]}})


### PR DESCRIPTION
Updated dependencies to latest versions.

`lein test` works, but I do need to change some code because when I run run an application that uses this version with the updated dependencies using`[mediquest-nl/module.web "5cbd71a4798d139a72293fcacf3022ed782635b2"]` I get this error:

```sh
Syntax error (ClassNotFoundException) compiling . at (ring/middleware/multipart_params.clj:29:5).
org.apache.commons.io.function.IOIterator
```

I will look into this tomorrow.

---

If the version of duct/server.http.jetty with updated dependencies from the PR https://github.com/duct-framework/server.http.jetty/pull/8 is released, I will add that version in this PR.